### PR TITLE
Fix: Use `Xdebug` instead of `pcov` for collecting code coverage

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -89,7 +89,7 @@ to run all the tests.
 
 We are using [`infection/infection`](https://github.com/infection/infection) to ensure a minimum quality of the tests.
 
-Enable `pcov` or `Xdebug` and run
+Enable `Xdebug` and run
 
 ```sh
 $ make mutation-tests

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: "Install PHP with extensions"
         uses: "shivammathur/setup-php@2.17.1"
         with:
-          coverage: "pcov"
+          coverage: "xdebug"
           extensions: "${{ env.PHP_EXTENSIONS }}"
           php-version: "${{ matrix.php-version }}"
 
@@ -63,7 +63,7 @@ jobs:
       - name: "Warm up cache"
         run: "bin/console cache:warmup"
 
-      - name: "Collect code coverage with pcov and phpunit/phpunit"
+      - name: "Collect code coverage with Xdebug and phpunit/phpunit"
         run: "vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-clover=.build/phpunit/logs/clover.xml"
 
       - name: "Send code coverage report to Codecov.io"
@@ -207,7 +207,7 @@ jobs:
       - name: "Install PHP with extensions"
         uses: "shivammathur/setup-php@2.17.1"
         with:
-          coverage: "pcov"
+          coverage: "xdebug"
           extensions: "${{ env.PHP_EXTENSIONS }}"
           php-version: "${{ matrix.php-version }}"
 
@@ -232,7 +232,7 @@ jobs:
       - name: "Warm up cache"
         run: "bin/console cache:warmup"
 
-      - name: "Run mutation tests with pcov and infection/infection"
+      - name: "Run mutation tests with Xdebug and infection/infection"
         run: "vendor/bin/infection --configuration=infection.json"
 
   static-code-analysis:


### PR DESCRIPTION
This pull request

- [x] uses `Xdebug` instead of `pcov` for collecting code coverage