### PR TITLE
Fix: Require `ext-pdo_sqlite`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
     "symfony/symfony": "*"
   },
   "require-dev": {
+    "ext-pdo_sqlite": "*",
     "dama/doctrine-test-bundle": "^6.5.0",
     "ergebnis/composer-normalize": "^2.13.3",
     "ergebnis/factory-bot": "~0.3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f5e9babc22d8177c9b5bce6c08146f1",
+    "content-hash": "817b8c805f00166e9bacea7530018145",
     "packages": [
         {
             "name": "brick/math",
@@ -10528,7 +10528,9 @@
         "ext-iconv": "*",
         "ext-pdo_pgsql": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {
+        "ext-pdo_sqlite": "*"
+    },
     "platform-overrides": {
         "php": "7.4.3"
     },


### PR DESCRIPTION
This pull request

- [x] requires `ext-pdo_sqlite` as development dependency